### PR TITLE
fix(security): add permissions to codeql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze Code


### PR DESCRIPTION
This pull request resolves the `missing-workflow-permissions` code scanning alert by adding the necessary `permissions` block to the CodeQL workflow file.

This addresses alert #1.

---
*This issue was created by an AI agent. You can find the original conversation [here](https://nos-gpt-staging.oizys.clg.nos.pt/share/oUfygabmN85rk-TudT-vb)*